### PR TITLE
Slow update frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ var MemDeviceRegistry = require('./memory_device_registry');
 var MemPeerRegistry = require('./memory_peer_registry');
 var UsageApp = require('zetta-usage-addon');
 
-var app = new UsageApp()
+var options = {};
 
+// Once hub is connected only send metrics every 30 seconds
+//options.publishFrequency = 30000;
+//options.publishHeaders  = true|falsey
+//options.ignoredHeaders = []; Headers to stripout 
+//options.enableApi = true|false. Usage api /usage
+
+var app = new UsageApp(options)
 
 zetta({registry: new MemDeviceRegistry(), peerRegistry: new MemPeerRegistry()})
   .name('server.1')

--- a/package.json
+++ b/package.json
@@ -4,13 +4,8 @@
   "description": "Basic usage stats for zetta",
   "main": "usage_app.js",
   "devDependencies": {
-    "levelup": "^0.19.0",
-    "memdown": "^1.0.0",
-    "zetta": "^0.22.0",
-    "zetta-photocell-mock-driver": "^0.4.0"
-  },
-  "devDependencies": {
     "mocha": "^2.4.5",
+    "supertest": "^1.2.0",
     "zetta": "^1.0.0",
     "zetta-cluster": "^6.3.0",
     "zetta-photocell-mock-driver": "^0.9.0"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
     "zetta": "^0.22.0",
     "zetta-photocell-mock-driver": "^0.4.0"
   },
+  "devDependencies": {
+    "mocha": "^2.4.5",
+    "zetta": "^1.0.0",
+    "zetta-cluster": "^6.3.0",
+    "zetta-photocell-mock-driver": "^0.9.0"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/mocha/bin/mocha test -t 10000"
   },
   "author": "Matthew Dobson <mdobson4@gmail.com>",
   "license": "MIT",

--- a/test/test_collection.js
+++ b/test/test_collection.js
@@ -1,0 +1,96 @@
+var assert = require('assert');
+var zetta = require('zetta');
+var zettacluster = require('zetta-cluster');
+
+var Photocell = require('zetta-photocell-mock-driver');
+var UsageApp = require('../');
+
+describe('ZettaUsage', function() {
+  
+  it('receives usage from hub', function(done) {
+    var collector = new UsageApp();
+
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect()])
+        .server('test1', [Photocell], ['cloud']);
+
+    collector.once('data', function(msg) {
+      assert.equal(msg.name, 'test1');
+      assert.equal(msg.active, true);
+      assert(msg.connectionId);
+      assert(msg.connected);
+      assert.equal(typeof msg.bytesRead, 'number');
+      assert.equal(typeof msg.bytesWritten, 'number');
+      cluster.stop();
+      setTimeout(done, 10);
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
+
+  it('receives a usage with active=false when hub disconnects', function(done) {
+    var collector = new UsageApp();
+
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect()])
+        .server('test1', [Photocell], ['cloud']);
+
+    cluster.on('ready', function() {
+      collector.once('data', function(msg) {
+        assert(msg.disconnected);
+        assert.equal(msg.active, false);
+        cluster.stop();
+        setTimeout(done, 10);
+      });
+
+      cluster.servers['cloud'].httpServer.peers['test1'].close()
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
+
+  it('will only emit data events at internal set in options', function(done) {
+    var interval = 1000;
+    var delay = 3000;
+    var collector = new UsageApp({ publishFrequency: interval });
+    var dataCollector = function(runtime) {
+      runtime.pubsub.subscribe('_peer/connect', function(ev, msg) {
+        msg.peer.subscribe('**');
+      });
+    };
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect(), dataCollector])
+        .server('test1', [Photocell], ['cloud']);
+
+    var received = 0;
+    cluster.on('ready', function() {
+      collector.on('data', function(msg) {
+        received++;
+      });
+    });
+
+    setTimeout(function() {
+      var c = delay/interval;
+      assert(received > c-1 && received < c+1, 'should have received ' + c + ' but instead received ' + received);
+      cluster.stop();
+      setTimeout(done, 10);
+    }, delay)
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  })
+   
+});

--- a/test/test_collection.js
+++ b/test/test_collection.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var request = require('supertest');
 var zetta = require('zetta');
 var zettacluster = require('zetta-cluster');
 
@@ -8,7 +9,7 @@ var UsageApp = require('../');
 describe('ZettaUsage', function() {
   
   it('receives usage from hub', function(done) {
-    var collector = new UsageApp();
+    var collector = new UsageApp({ publishFrequency: 10 });
 
     var cluster = zettacluster({ zetta: zetta })
         .server('cloud', [collector.collect()])
@@ -34,7 +35,7 @@ describe('ZettaUsage', function() {
 
 
   it('receives a usage with active=false when hub disconnects', function(done) {
-    var collector = new UsageApp();
+    var collector = new UsageApp({ publishFrequency: 10000 });
 
     var cluster = zettacluster({ zetta: zetta })
         .server('cloud', [collector.collect()])
@@ -61,7 +62,7 @@ describe('ZettaUsage', function() {
 
   it('will only emit data events at internal set in options', function(done) {
     var interval = 1000;
-    var delay = 3000;
+    var delay = interval*3 + interval/4;
     var collector = new UsageApp({ publishFrequency: interval });
     var dataCollector = function(runtime) {
       runtime.pubsub.subscribe('_peer/connect', function(ev, msg) {
@@ -92,5 +93,93 @@ describe('ZettaUsage', function() {
       }
     });
   })
+
+  it('includes headers that are not ignored', function(done) {
+    var collector = new UsageApp({ publishFrequency: 10, ignoredHeaders: ['host'] });
+
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect()])
+        .server('test1', [Photocell], ['cloud']);
+
+    collector.once('data', function(msg) {
+      assert.equal(Object.keys(msg.headers).length, 4);
+      cluster.stop();
+      setTimeout(done, 10);
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
+  it('publishHeaders disables headers in message', function(done) {
+    var collector = new UsageApp({ publishFrequency: 10, publishHeaders: false });
+
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect()])
+        .server('test1', [Photocell], ['cloud']);
+
+    collector.once('data', function(msg) {
+      assert.equal(msg.headers, undefined);
+      cluster.stop();
+      setTimeout(done, 10);
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
+  it('api enabled by default /', function(done) {
+    var collector = new UsageApp({ publishFrequency: 10 });
+
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect()])
+        .server('test1', [Photocell], ['cloud']);
+
+    cluster.once('ready', function() {
+      request(cluster.servers['cloud'].httpServer.server)
+        .get('/usage')
+        .expect(function(res) {
+          var json = JSON.parse(res.text);
+          assert(json.class.indexOf('usage') >= 0);
+          assert.equal(json.links.length, 2);
+          assert.equal(json.entities.length, 1);
+        })
+        .end(done);
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
+  it('enableApi would disables api when false', function(done) {
+    var collector = new UsageApp({ enableApi: false });
+
+    var cluster = zettacluster({ zetta: zetta })
+        .server('cloud', [collector.collect()])
+        .server('test1', [Photocell], ['cloud']);
+
+    cluster.once('ready', function() {
+      request(cluster.servers['cloud'].httpServer.server)
+        .get('/usage')
+        .expect(404)
+        .end(done);
+    });
+
+    cluster.run(function(err) {
+      if (err) {
+        done(err);
+      }
+    });
+  });
+
    
 });

--- a/usage_app.js
+++ b/usage_app.js
@@ -2,10 +2,32 @@ var UsageResource = require('./usage_resource');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
-var Usage = module.exports = function() {
+// Headers to strip
+
+var IGNORED_HEADERS = ['connection',
+                      'sec-websocket-version',
+                      'upgrade',
+                      'sec-websocket-key',
+                      'authorization',
+                      'host'];
+
+var Usage = module.exports = function(options) {
+  if (options === undefined) {
+    options = {};
+  }
+
+  // Once hub is connected only send metrics every 30 seconds
+  this.publishFrequency = options.publishFrequency || 30000; // 30s
+
+  this.publishHeaders = (options.publishHeaders === undefined) ? true : !!(options.publishHeaders);
+  this.ignoredHeaders = options.ignoredHeaders || IGNORED_HEADERS;
+  this.enableApi = (options.enableApi === undefined) ? true : !!(options.enableApi);
+
   EventEmitter.call(this);
 };
 util.inherits(Usage, EventEmitter);
+
+Usage.IGNORED_HEADERS = IGNORED_HEADERS;
 
 Usage.prototype.collect = function() {
   var self = this;
@@ -14,33 +36,60 @@ Usage.prototype.collect = function() {
     var requestServer = server.httpServer.server;
     var name = server.httpServer.zetta.id;
     var usage = {};
-    cloud.add(UsageResource, usage, name);
+    var timers = {};
+
+    if (self.enableApi) {
+      cloud.add(UsageResource, usage, name);
+    }
+
     server.pubsub.subscribe('_peer/connect', function(ev, socket) {
       var name = socket.peer.name;
       var agentSocket = socket.peer.agent.socket;
       var connectionId = socket.peer.connectionId;
-      usage[connectionId] = { name: name, connectionId: connectionId, headers: socket.peer.ws.upgradeReq.headers };
+      usage[connectionId] = { name: name, connectionId: connectionId };
+
+      if (self.publishHeaders) {
+        usage[connectionId].headers = {};
+        Object.keys(socket.peer.ws.upgradeReq.headers).forEach(function(k) {
+          if (self.ignoredHeaders.indexOf(k) >= 0) {
+            return;
+          }
+          usage[connectionId].headers[k] = socket.peer.ws.upgradeReq.headers[k];
+        });
+      }
+      
       usage[connectionId].bytesWritten = 0;
       usage[connectionId].bytesRead = 0;  
       usage[connectionId].active = true;
       usage[connectionId].connected = new Date().getTime();
 
-      agentSocket.on('data', function(d) {
+      timers[connectionId] = setInterval(function() {
         usage[connectionId].bytesWritten = agentSocket.bytesWritten;
-        usage[connectionId].bytesRead = agentSocket.bytesRead;  
+        usage[connectionId].bytesRead = agentSocket.bytesRead;
         usage[connectionId].active = true;
+
         self.emit('data', usage[connectionId]);
-      });
+      }, self.publishFrequency);
     });
 
     server.pubsub.subscribe('_peer/disconnect', function(ev, socket) {
       var connectionId = socket.peer.connectionId
-      if(!usage[connectionId]) {
-        usage[connectionId] = {};
+
+      clearInterval(timers[connectionId]);
+      delete timers[connectionId];
+
+      if (!usage[connectionId]) {
+        return;
       }
+
+      var agentSocket = socket.peer.agent.socket;
+      usage[connectionId].bytesWritten = agentSocket.bytesWritten;
+      usage[connectionId].bytesRead = agentSocket.bytesRead;
       usage[connectionId].active = false;  
       usage[connectionId].disconnected = new Date().getTime();
+
       self.emit('data', usage[connectionId]);
+      delete usage[connectionId];
     });
   }  
 };


### PR DESCRIPTION
Will only emit data every 30s by default and when the connection closes. Can be updated with `publishFrequency`. You can now optionally publish headers and set what headers are ignored. And optionally enable the api resource.
